### PR TITLE
Feature mainloop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ READLINE	= lib/readline/lib/libreadline.a
 RL_VERSION	= readline-8.1.2
 CFLAGS		= -Wall -Werror -Wextra
 LINK_FLAGS	= -L ./lib/readline/lib -lreadline -lhistory
-INCLUDE		= -I lib/readline/include
+INCLUDE		= -I ./lib/readline/include
 
 GREEN		= \033[0;32m
 CYAN		= \033[0;36m

--- a/src/main.c
+++ b/src/main.c
@@ -1,10 +1,41 @@
+#include <stdlib.h>
 #include <stdio.h>
+#include <unistd.h>
 #include <readline/readline.h>
+#include <signal.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <termios.h>
+#include "../lib/libft/libft.h"
+
+static void	signalhandler(int sig);
 
 int	main(void)
 {
+	char				*input;
+
+	signal(SIGQUIT, SIG_IGN);
+	signal(SIGINT, &signalhandler);
 	while (1)
 	{
-		readline("\033[0;31msigmashell \033[0;32m> \033[0;37m");
+		input = readline("\033[0;31msigmashell \033[0;32m> \033[0;37m");
+		if (input == NULL)
+		{
+			rl_replace_line("TEST", 0);
+			rl_redisplay();
+			exit(EXIT_SUCCESS);
+		}
+	}
+	return (EXIT_SUCCESS);
+}
+
+static void	signalhandler(int sig)
+{
+	if (sig == SIGINT)
+	{
+		write(STDERR_FILENO, "\n", 1);
+		rl_replace_line("", 0);
+		rl_on_new_line();
+		rl_redisplay();
 	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <readline/readline.h>
+
+int	main(void)
+{
+	while (1)
+	{
+		readline("\033[0;31msigmashell \033[0;32m> \033[0;37m");
+	}
+}


### PR DESCRIPTION
Added main loop that is only interrupted when pressing Ctrl-D. Ctrl+\ is ignored and Ctrl+C returns a newline (sadly still printing the ^C)