### PR TITLE
Modify expand

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -23,7 +23,7 @@ void	print_lexed_lst(t_list *lst);
 void	init_signalhandlers(void);
 t_list	*analyzer(char *str);
 t_list	*parse(t_list *lexed_args);
-t_list	*expand(t_list *command_table, char **env);
+void	expand(t_list **command_table, char **env);
 int		builtin_controller_parent(t_list *cmds, t_command *cmd, char ***env);
 int		builtin_controller_child(t_command *cmd, char **env);
 void	executor(t_list	*commands, char ***env);

--- a/src/builtins/export.c
+++ b/src/builtins/export.c
@@ -34,10 +34,16 @@ int	ft_export(char ***env, char **options)
 static void	print_error(char **env)
 {
 	size_t	i;
+	char	*str;
 
 	i = 0;
+	str = NULL;
 	if (env == NULL)
 		return ;
 	while (env[i] != NULL)
-		printf("declare -x %s\n", env[i++]);
+	{
+		str = ft_strjoin("declare -x", env[i++]);
+		ft_putendl_fd(str, 2);
+		free(str);
+	}
 }

--- a/src/expander/expander.c
+++ b/src/expander/expander.c
@@ -4,25 +4,19 @@ char	*expand_string(char *command, char **env);
 char	*get_env_value(char *var, char **env);
 char	**expand_options(char **options, char **env);
 
-t_list	*expand(t_list *command_table, char **env)
+void	expand(t_list **command_table, char **env)
 {
-	t_list		*res;
-	t_list		*del;
-	t_command	*temp;
+	t_list		*tmp;
+	t_command	*current;
 
-	res = ft_lstnew(NULL);
-	while (command_table != NULL)
+	tmp = *command_table;
+	while (tmp != NULL)
 	{
-		temp = command_table->content;
-		temp->command = expand_string(temp->command, env);
-		temp->options = expand_options(temp->options, env);
-		ft_lstadd_back(&res, ft_lstnew(temp));
-		command_table = command_table->next;
+		current = tmp->content;
+		current->command = expand_string(current->command, env);
+		current->options = expand_options(current->options, env);
+		tmp = tmp->next;
 	}
-	del = res;
-	res = res->next;
-	ft_lstdelone(del, free);
-	return (res);
 }
 
 char	**expand_options(char **options, char **env)

--- a/src/main.c
+++ b/src/main.c
@@ -52,17 +52,16 @@ static void	logic(char *input, char ***env)
 {
 	t_list	*command_table;
 	t_list	*lexed_args;
-	t_list	*expanded_command_table;
 
 	lexed_args = analyzer(input);
-	//print_lexed_lst(lexed_args);
+	print_lexed_lst(lexed_args);
 	command_table = parse(lexed_args);
 	ft_lstclear(&lexed_args, del_token);
-	// ft_printf("COMMAND TABLE\n");
-	// print_parsed_lst(command_table);
-	expanded_command_table = expand(command_table, *env);
-	// ft_printf("EXPANDED COMMAND TABLE\n");
-	// print_parsed_lst(expanded_command_table);
+	ft_printf("COMMAND TABLE\n");
+	print_parsed_lst(command_table);
+	expand(&command_table, *env);
+	ft_printf("EXPANDED COMMAND TABLE\n");
+	print_parsed_lst(command_table);
 	executor(command_table, env);
 	printf("\033[0;32mexit_code: \033[0m%d\n", exit_code);
 	ft_lstclear(&command_table, &free_cmd);

--- a/src/main.c
+++ b/src/main.c
@@ -55,14 +55,14 @@ static void	logic(char *input, char ***env)
 	t_list	*expanded_command_table;
 
 	lexed_args = analyzer(input);
-	print_lexed_lst(lexed_args);
+	//print_lexed_lst(lexed_args);
 	command_table = parse(lexed_args);
 	ft_lstclear(&lexed_args, del_token);
-	ft_printf("COMMAND TABLE\n");
-	print_parsed_lst(command_table);
+	// ft_printf("COMMAND TABLE\n");
+	// print_parsed_lst(command_table);
 	expanded_command_table = expand(command_table, *env);
-	ft_printf("EXPANDED COMMAND TABLE\n");
-	print_parsed_lst(expanded_command_table);
+	// ft_printf("EXPANDED COMMAND TABLE\n");
+	// print_parsed_lst(expanded_command_table);
 	executor(command_table, env);
 	printf("\033[0;32mexit_code: \033[0m%d\n", exit_code);
 	ft_lstclear(&command_table, &free_cmd);


### PR DESCRIPTION
The expand function was modified so that it changes the original command_table from parsing, instead of returning a new one. This change prevents the recent Leaks.