### PR TITLE
98 stdin tests

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -2,6 +2,14 @@
 
 static char	*ft_readline(void);
 
+/*
+ * for bash replication add
+ * ft_putstr_fd("\x1b[1A", STDOUT_FILENO);
+ * ft_putstr_fd("\033[35C", STDOUT_FILENO);
+ * ft_putendl_fd("exit", STDOUT_FILENO);
+ * to the input == NULL statement
+ */
+
 char	*get_input(char **env)
 {
 	char	*input;
@@ -13,9 +21,6 @@ char	*get_input(char **env)
 	add_history(input);
 	if (input == NULL)
 	{
-		ft_putstr_fd("\x1b[1A", STDOUT_FILENO);
-		ft_putstr_fd("\033[35C", STDOUT_FILENO);
-		ft_putendl_fd("exit", STDOUT_FILENO);
 		clear_history();
 		ft_free_stra(env);
 		exit(EXIT_SUCCESS);

--- a/tests/tester.sh
+++ b/tests/tester.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Change if you store the tester in another PATH
-export MINISHELL_PATH=~/projects/minishell/
+export MINISHELL_PATH=../
 export EXECUTABLE=minishell
 
 NL=$'\n'


### PR DESCRIPTION
this pr fixes some issues with the tester that were caused by the printing of 'exit' on Ctrl-D keypress