### PR TITLE
fix heredoc delimiter comparsion

### DIFF
--- a/src/parser/parser_utils.c
+++ b/src/parser/parser_utils.c
@@ -51,24 +51,24 @@ void	free_cmd(void *pointer)
 	free(command);
 }
 
-int	ft_here_doc(char *delimiter, char **env)
+int	ft_here_doc(char *delim, char **env)
 {
 	char	*str;
-	char	*delimit_signal;
+	char	*delimiter;
 	int		src[2];
 
 	if (pipe(src))
 		ft_printf("here doc failed, errorcodes not yet existent\n");
 	str = get_next_line(0);
-	delimit_signal = ft_strjoin(delimiter, "\n");
-	while (str && ft_strncmp(delimit_signal, str, ft_strlen(str) - 1))
+	delimiter = ft_strjoin(delim, "\n");
+	while (str && ft_strncmp(str, delimiter, ft_strlen(delimiter) - 1))
 	{
 		str = expand_string(str, env);
 		ft_putstr_fd(str, src[1]);
 		free(str);
 		str = get_next_line(0);
 	}
-	free(delimit_signal);
+	free(delimiter);
 	if (str != NULL)
 		free(str);
 	close(src[1]);


### PR DESCRIPTION
<img width="469" alt="Screen Shot 2023-03-14 at 8 34 37 AM" src="https://user-images.githubusercontent.com/51891575/224927970-7a8f6f36-f691-462a-82c4-9cd3eeb639a4.png">
this pr fixes the here_doc comparsion error from issue #110 